### PR TITLE
Fix code quality issues and compiler warnings

### DIFF
--- a/src/ObjectTreeWalker/MemberAccessor.cs
+++ b/src/ObjectTreeWalker/MemberAccessor.cs
@@ -1,4 +1,5 @@
-// ReSharper disable TooManyChainedReferences
+// Copyright (c) Michael Yarichuk. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
 
@@ -40,7 +41,7 @@ public readonly struct MemberAccessor
     public MemberType MemberType => _memberInfo.MemberType;
 
     /// <summary>
-    /// Exposing raw data, needed for internal functionality
+    /// Gets exposing raw data, needed for internal functionality
     /// </summary>
     internal ObjectMemberInfo RawInfo => _memberInfo;
 
@@ -102,9 +103,10 @@ public readonly struct MemberAccessor
                 var objectType = parentOfParentRef.Value.Instance.GetType();
                 var parentOfParentRefAccessor = new ObjectAccessor(objectType);
 
-                if (!parentOfParentRefAccessor.TryGetValue(parentOfParentRef.Value.Instance,
-                        parentOfParentRef.Value.Name,
-                        out var properParentInstance))
+                if (!parentOfParentRefAccessor.TryGetValue(
+                    parentOfParentRef.Value.Instance,
+                    parentOfParentRef.Value.Name,
+                    out var properParentInstance))
                 {
                     throw new InvalidOperationException(
                         "Failed to set embedded struct value, this is not supposed to happen and is likely a bug.");

--- a/src/ObjectTreeWalker/MemberType.cs
+++ b/src/ObjectTreeWalker/MemberType.cs
@@ -23,6 +23,6 @@ namespace ObjectTreeWalker
         /// <summary>
         /// Indicates that a member is an item in a collection
         /// </summary>
-        CollectionItem
+        CollectionItem,
     }
 }

--- a/src/ObjectTreeWalker/ObjectAccessor.cs
+++ b/src/ObjectTreeWalker/ObjectAccessor.cs
@@ -5,8 +5,8 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Sigil;
-// ReSharper disable ComplexConditionExpression
 
+// ReSharper disable ComplexConditionExpression
 namespace ObjectTreeWalker;
 
 /// <summary>

--- a/src/ObjectTreeWalker/ObjectEnumerator.cs
+++ b/src/ObjectTreeWalker/ObjectEnumerator.cs
@@ -2,10 +2,10 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+
 // ReSharper disable ComplexConditionExpression
 // ReSharper disable MethodTooLong
 // ReSharper disable CognitiveComplexity
-
 namespace ObjectTreeWalker
 {
     /// <summary>

--- a/src/ObjectTreeWalker/ObjectMemberInfo.cs
+++ b/src/ObjectTreeWalker/ObjectMemberInfo.cs
@@ -1,4 +1,6 @@
-// ReSharper disable TooManyDependencies
+// Copyright (c) Michael Yarichuk. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace ObjectTreeWalker;
 
 /// <summary>
@@ -27,7 +29,6 @@ internal readonly struct ObjectMemberInfo
     /// Gets parent object instance
     /// </summary>
     public readonly object Instance;
-
 
     /// <summary>
     /// property and it's parents in-order

--- a/src/ObjectTreeWalker/ObjectMemberIterator.cs
+++ b/src/ObjectTreeWalker/ObjectMemberIterator.cs
@@ -4,8 +4,8 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.ObjectPool;
-// ReSharper disable ComplexConditionExpression
 
+// ReSharper disable ComplexConditionExpression
 namespace ObjectTreeWalker
 {
     /// <summary>
@@ -45,10 +45,11 @@ namespace ObjectTreeWalker
     {
         private static readonly ConcurrentDictionary<Type, ObjectAccessor> ObjectAccessorCache = new();
         private static readonly object EmptyContext = new();
+        private static ObjectEnumerator.Settings? _enumeratorSettings;
+
         private static readonly ObjectPool<Queue<(MemberAccessor IterationItem, ObjectGraphNode Node)>> TraversalQueuePool =
             new DefaultObjectPoolProvider().Create<Queue<(MemberAccessor IterationItem, ObjectGraphNode Node)>>();
 
-        private static ObjectEnumerator.Settings? _enumeratorSettings;
         private readonly ObjectEnumerator _objectEnumerator;
 
         /// <summary>
@@ -78,6 +79,10 @@ namespace ObjectTreeWalker
 
             _objectEnumerator = new(_enumeratorSettings);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ObjectAccessor GetCachedObjectAccessor(Type type) =>
+            ObjectAccessorCache.GetOrAdd(type, t => new ObjectAccessor(t));
 
         /// <summary>
         /// Traverse over object members and possibly apply action to mutate the data
@@ -111,7 +116,7 @@ namespace ObjectTreeWalker
                             obj,
                             null,
                             root.MemberInfo.GetUnderlyingType()!,
-                            new [] { new PropertyPathItem(root.Name) }),
+                            new[] { new PropertyPathItem(root.Name) }),
                         rootObjectAccessor), root));
             }
         }
@@ -134,7 +139,7 @@ namespace ObjectTreeWalker
                             obj,
                             new Ref<ObjectMemberInfo>(rawData),
                             root.MemberInfo.GetUnderlyingType()!,
-                            new [] { new PropertyPathItem(root.Name) }),
+                            new[] { new PropertyPathItem(root.Name) }),
                         rootObjectAccessor), root));
             }
         }
@@ -325,12 +330,9 @@ namespace ObjectTreeWalker
 
             return context;
 
-            string PropertyNameWithIndex((MemberAccessor IterationItem, ObjectGraphNode Node) current, int index) => 
+            string PropertyNameWithIndex((MemberAccessor IterationItem, ObjectGraphNode Node) current, int index) =>
                 $"{current.Node.Name}[{index}]";
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ObjectAccessor GetCachedObjectAccessor(Type type) =>
-            ObjectAccessorCache.GetOrAdd(type, t => new ObjectAccessor(t));
     }
 }

--- a/src/ObjectTreeWalker/ObjectTreeWalker.csproj
+++ b/src/ObjectTreeWalker/ObjectTreeWalker.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <Nullable>enable</Nullable>
     <Title>Object Tree Walker</Title>
     <Description>A simple utility class that allows traversing over C# object properties, Node.js style</Description>

--- a/tests/ObjectTreeWalker.Tests/ObjectEnumeratorTests.cs
+++ b/tests/ObjectTreeWalker.Tests/ObjectEnumeratorTests.cs
@@ -19,7 +19,7 @@ namespace ObjectTreeWalker.Tests
 
         public class ObjWithString
         {
-            public string Str { get; set; }
+            public string? Str { get; set; }
         }
 
         public class ObjWithDecimal
@@ -29,7 +29,7 @@ namespace ObjectTreeWalker.Tests
 
         public class ObjWithDynamic
         {
-            public dynamic DynamicObj { get; set; }
+            public dynamic? DynamicObj { get; set; }
         }
 
         public class FlatObj

--- a/tests/ObjectTreeWalker.Tests/ObjectMemberIteratorTests.cs
+++ b/tests/ObjectTreeWalker.Tests/ObjectMemberIteratorTests.cs
@@ -87,7 +87,7 @@ namespace ObjectTreeWalker.Tests
 
         public class ObjectWithUpcastProperty
         {
-            public object Value { get; set; }
+            public object? Value { get; set; }
         }
 
         public struct JustAFoobarStruct
@@ -120,7 +120,7 @@ namespace ObjectTreeWalker.Tests
         {
             public int NumProperty { get; set; }
 
-            public string StringProperty { get; set; }
+            public string? StringProperty { get; set; }
 
             public BarFooAsStruct Embedded { get; set; }
         }
@@ -129,7 +129,7 @@ namespace ObjectTreeWalker.Tests
         {
             public int NumProperty { get; set; }
 
-            public string StringProperty { get; set; }
+            public string? StringProperty { get; set; }
 
             public BarFooAsStruct Embedded { get; set; }
         }
@@ -157,7 +157,7 @@ namespace ObjectTreeWalker.Tests
             /// Must be a derivative of <code>ValueType</code>.</param>
             public ValueTypeHolder(object value)
             {
-                Value = (ValueType) value;
+                Value = (ValueType)value;
             }
 
             /// <summary>
@@ -348,7 +348,9 @@ namespace ObjectTreeWalker.Tests
         [InlineData(typeof(JustAFoobarStruct))]
         public void Can_iterate_uninitialized_object(Type typeOfObject)
         {
+            #pragma warning disable SYSLIB0050
             var emptyInstance = FormatterServices.GetUninitializedObject(typeOfObject);
+#pragma warning restore SYSLIB0050
             var iterator = new ObjectMemberIterator();
 
             iterator.Traverse(emptyInstance, (in MemberAccessor accessor) =>
@@ -378,7 +380,9 @@ namespace ObjectTreeWalker.Tests
         [Fact]
         public void Can_iterate_wrapped_struct()
         {
+            #pragma warning disable SYSLIB0050
             var emptyInstance = (JustAFoobarStruct)FormatterServices.GetUninitializedObject(typeof(JustAFoobarStruct));
+#pragma warning restore SYSLIB0050
             var wrappedInstance = new ValueTypeHolder(emptyInstance);
 
             var iterator = new ObjectMemberIterator();
@@ -410,8 +414,10 @@ namespace ObjectTreeWalker.Tests
         [Fact]
         public void Can_iterate_wrapped_obj()
         {
+            #pragma warning disable SYSLIB0050
             var emptyInstance = (JustAFoobarObj)FormatterServices.GetUninitializedObject(typeof(JustAFoobarObj));
-            var wrappedInstance = new ObjectWithUpcastProperty{ Value = emptyInstance };
+#pragma warning restore SYSLIB0050
+            var wrappedInstance = new ObjectWithUpcastProperty { Value = emptyInstance };
 
             var iterator = new ObjectMemberIterator();
 
@@ -446,7 +452,9 @@ namespace ObjectTreeWalker.Tests
         [InlineData(typeof(ObjectWithEmbeddedStruct))]
         public void Can_iterate_embedded_property(Type type)
         {
+            #pragma warning disable SYSLIB0050
             var instance = FormatterServices.GetUninitializedObject(type);
+#pragma warning restore SYSLIB0050
             var iterator = new ObjectMemberIterator();
 
             iterator.Traverse(instance, (in MemberAccessor accessor) =>
@@ -468,7 +476,9 @@ namespace ObjectTreeWalker.Tests
 
                 if (accessor.Name.Contains("Embedded"))
                 {
+                    #pragma warning disable SYSLIB0050
                     var embeddedObject = (dynamic)FormatterServices.GetUninitializedObject(accessor.Type);
+#pragma warning restore SYSLIB0050
                     embeddedObject.AnotherNumProperty = 123;
                     accessor.SetValue(embeddedObject);
                 }
@@ -641,15 +651,15 @@ namespace ObjectTreeWalker.Tests
 
             Assert.Collection(propertyPaths,
                 propertyPath =>
-                    Assert.Equal("Foo1", string.Join(",",propertyPath.Select(x => x.Name))),
+                    Assert.Equal("Foo1", string.Join(",", propertyPath.Select(x => x.Name))),
                 propertyPath =>
-                    Assert.Equal("Foo4", string.Join(",",propertyPath.Select(x => x.Name))),
+                    Assert.Equal("Foo4", string.Join(",", propertyPath.Select(x => x.Name))),
                 propertyPath =>
-                    Assert.Equal("Obj,Foo1", string.Join(",",propertyPath.Select(x => x.Name))),
+                    Assert.Equal("Obj,Foo1", string.Join(",", propertyPath.Select(x => x.Name))),
                 propertyPath =>
-                    Assert.Equal("Obj,Foo2", string.Join(",",propertyPath.Select(x => x.Name))),
+                    Assert.Equal("Obj,Foo2", string.Join(",", propertyPath.Select(x => x.Name))),
                 propertyPath =>
-                    Assert.Equal("Obj,Foo3", string.Join(",",propertyPath.Select(x => x.Name)))
+                    Assert.Equal("Obj,Foo3", string.Join(",", propertyPath.Select(x => x.Name)))
             );
         }
 
@@ -718,11 +728,10 @@ namespace ObjectTreeWalker.Tests
         public void Can_iterate_collection_property(Type t)
         {
             var iterator = new ObjectMemberIterator();
-            var arraySum = 0;
             int[] expectedArray = [123, 456, 789];
             var fetchedItems = new List<int>();
 
-            iterator.Traverse(Activator.CreateInstance(t), (in MemberAccessor accessor) =>
+            iterator.Traverse(Activator.CreateInstance(t)!, (in MemberAccessor accessor) =>
             {
                 var propertyPathAsString = accessor.PropertyPath.Select(x => x.Name);
                 if (accessor.PropertyPath.Last().IsPartOfCollection)
@@ -741,11 +750,10 @@ namespace ObjectTreeWalker.Tests
         public void Can_iterate_deep_collection_property(Type t)
         {
             var iterator = new ObjectMemberIterator();
-            var arraySum = 0;
             int[] expectedArray = [123, 456, 789];
             var fetchedItems = new List<int>();
 
-            iterator.Traverse(Activator.CreateInstance(t), (in MemberAccessor accessor) =>
+            iterator.Traverse(Activator.CreateInstance(t)!, (in MemberAccessor accessor) =>
             {
                 if (accessor.RawInfo.MemberType == MemberType.CollectionItem)
                 {
@@ -753,7 +761,7 @@ namespace ObjectTreeWalker.Tests
                 }
             });
 
-            Assert.Equal(expectedArray.Concat(expectedArray).Concat(expectedArray).OrderBy(x => x), 
+            Assert.Equal(expectedArray.Concat(expectedArray).Concat(expectedArray).OrderBy(x => x),
                 fetchedItems.OrderBy(x => x));
         }
     }


### PR DESCRIPTION
I addressed a variety of code quality issues and compiler warnings during the code review:
- Suppressed `SYSLIB0050` warnings for `FormatterServices.GetUninitializedObject` in `ObjectMemberIteratorTests.cs`.
- Removed unused `arraySum` variables in `ObjectMemberIteratorTests.cs`.
- Reordered static fields in `ObjectMemberIterator.cs` to appear before non-static fields, resolving StyleCop warning `SA1214`.
- Added missing null-forgiving operators `!` to `Activator.CreateInstance(t)` calls in `ObjectMemberIteratorTests.cs` to resolve potential null reference warnings.
- Fixed array initializer spacing (`new[]`) in `ObjectMemberIterator.cs`.
- Suppressed framework support build warnings for .NET 6 via `<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>` in `ObjectTreeWalker.csproj`.

All tests pass.

---
*PR created automatically by Jules for task [18002386763560710604](https://jules.google.com/task/18002386763560710604) started by @myarichuk*