### PR TITLE
ci: fix NuGet trusted publishing and git auto-commit

### DIFF
--- a/.github/workflows/on-merge-pr.yml
+++ b/.github/workflows/on-merge-pr.yml
@@ -9,6 +9,10 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
+permissions:
+  id-token: write
+  contents: write
+
 concurrency:
   group: ${{ github.ref }}-publish-release
   cancel-in-progress: true
@@ -88,8 +92,6 @@ jobs:
         with:
           name: nupkg
           path: .
-      - name: Publish to NuGet via OIDC
-        uses: NuGet/setup-nuget@v2.0.0
       - run: dotnet nuget push ./*.nupkg -s https://api.nuget.org/v3/index.json
 
   changelog-release:
@@ -102,6 +104,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/download-artifact@v4
         with:
           name: nupkg
@@ -128,3 +132,4 @@ jobs:
         with:
           commit_message: 'docs: update CHANGELOG.md for ${{needs.build-and-pack.outputs.tag}}'
           file_pattern: CHANGELOG.md
+          branch: main


### PR DESCRIPTION
Resolves the CI failure during NuGet publishing by utilizing the native .NET SDK OIDC trusted publishing capabilities and removing the legacy `setup-nuget` step. Also fixes the `git-auto-commit-action` invalid branch reference error by explicitly checking out and pushing to the `main` branch.

---
*PR created automatically by Jules for task [7201800047992338801](https://jules.google.com/task/7201800047992338801) started by @myarichuk*