### PR TITLE
⚡ Cache reflection results in ObjectGraphNode properties

### DIFF
--- a/src/ObjectTreeWalker/ObjectGraphNode.cs
+++ b/src/ObjectTreeWalker/ObjectGraphNode.cs
@@ -10,12 +10,12 @@ internal record ObjectGraphNode
     /// <summary>
     /// Gets the name of the member (name of property/field)
     /// </summary>
-    public string Name => MemberInfo.Name;
+    public string Name { get; }
 
     /// <summary>
     /// Gets the type of the member
     /// </summary>
-    public Type Type => MemberInfo.GetUnderlyingType()!;
+    public Type Type { get; }
 
     /// <summary>
     /// Gets the reflection metadata of the member
@@ -56,6 +56,8 @@ internal record ObjectGraphNode
     public ObjectGraphNode(MemberInfo memberInfo, ObjectGraphNode? parent, IEnumerable<ObjectGraphNode>? children = null)
     {
         MemberInfo = memberInfo;
+        Name = memberInfo.Name;
+        Type = memberInfo.GetUnderlyingType()!;
         Parent = parent;
 
         if (children != null)


### PR DESCRIPTION
This PR optimizes `ObjectGraphNode` by converting computed properties `Name` and `Type` into auto-implemented properties that are initialized in the constructor. 

💡 **What:**
- Changed `Name` from `public string Name => MemberInfo.Name;` to a get-only property.
- Changed `Type` from `public Type Type => MemberInfo.GetUnderlyingType()!;` to a get-only property.
- Initialized both properties in the constructor.

🎯 **Why:**
These properties are accessed frequently during the traversal of the object graph. By caching the results of `MemberInfo.Name` and the `GetUnderlyingType()` extension method, we eliminate the overhead of repeated reflection-related calls and potential string allocations for each access.

📊 **Measured Improvement:**
Although full BenchmarkDotNet results could not be generated due to environment-related timeouts, this is a standard performance optimization in .NET that reduces both CPU cycles and memory allocations in hot code paths. 

The changes have been verified via code review and build checks.

---
*PR created automatically by Jules for task [14058397557434013349](https://jules.google.com/task/14058397557434013349) started by @myarichuk*